### PR TITLE
Have muting use Topic model

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2454,7 +2454,10 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
         subject = truncate_topic(subject)
         event["orig_subject"] = orig_subject
         event["propagate_mode"] = propagate_mode
-        message.subject = subject
+        if getattr(settings, 'CATCH_TOPIC_MIGRATION_BUGS', False):
+            message.subject = 'CATCH_TOPIC_MIGRATION_BUGS'
+        else:
+            message.subject = subject
 
         # We always create a new topic now for topic edits.  For the
         # "change_all" case, you could argue we should just reuse the old
@@ -2492,8 +2495,11 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
             for m in messages_list:
                 # The cached ORM object is not changed by messages.update()
                 # and the remote cache update requires the new value
-                m.subject = subject
                 m.topic_id = new_topic_id
+                if getattr(settings, 'CATCH_TOPIC_MIGRATION_BUGS', False):
+                    m.subject = 'CATCH_TOPIC_MIGRATION_BUGS'
+                else:
+                    m.subject = subject
 
             changed_messages += messages_list
 
@@ -2507,7 +2513,7 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
     message.edit_history = ujson.dumps(edit_history)
 
     log_event(event)
-    message.save(update_fields=["topic_id", "subject", "content", "rendered_content",
+    message.save(update_fields=["topic_id", "content", "rendered_content",
                                 "rendered_content_version", "last_edit_time",
                                 "edit_history"])
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2244,8 +2244,8 @@ def do_update_pointer(user_profile, pointer, update_flags=False):
     event = dict(type='pointer', pointer=pointer)
     send_event(event, [user_profile.id])
 
-def do_update_message_flags(user_profile, operation, flag, messages, all, stream_obj, topic_name):
-    # type: (UserProfile, str, str, Sequence[Message], bool, Optional[Stream], Optional[text_type]) -> int
+def do_update_message_flags(user_profile, operation, flag, messages, all, stream_obj, topic_id):
+    # type: (UserProfile, str, str, Sequence[Message], bool, Optional[Stream], Optional[int]) -> int
     flagattr = getattr(UserMessage.flags, flag)
 
     if all:
@@ -2253,10 +2253,10 @@ def do_update_message_flags(user_profile, operation, flag, messages, all, stream
         msgs = UserMessage.objects.filter(user_profile=user_profile)
     elif stream_obj is not None:
         recipient = get_recipient(Recipient.STREAM, stream_obj.id)
-        if topic_name:
-            msgs = UserMessage.objects.filter(message__recipient=recipient,
+        if topic_id:
+            msgs = UserMessage.objects.filter(message__topic_id=topic_id,
                                               user_profile=user_profile,
-                                              message__subject__iexact=topic_name)
+                                              )
         else:
             msgs = UserMessage.objects.filter(message__recipient=recipient, user_profile=user_profile)
     else:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2447,6 +2447,10 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
 
     if subject is not None:
         orig_subject = message.topic_name()
+        orig_topic_id = message.topic_id
+        if not orig_topic_id:
+            raise JsonableError(_('This message is locked due to migration.'))
+
         subject = truncate_topic(subject)
         event["orig_subject"] = orig_subject
         event["propagate_mode"] = propagate_mode
@@ -2468,7 +2472,7 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
         edit_history_event["prev_subject"] = orig_subject
 
         if propagate_mode in ["change_later", "change_all"]:
-            propagate_query = Q(recipient = message.recipient, subject = orig_subject)
+            propagate_query = Q(recipient = message.recipient, topic_id = orig_topic_id)
             # We only change messages up to 2 days in the past, to avoid hammering our
             # DB by changing an unbounded amount of messages
             if propagate_mode == 'change_all':

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -11,7 +11,7 @@ from django.core import validators
 from django.contrib.sessions.models import Session
 from zerver.lib.cache import flush_user_profile
 from zerver.lib.context_managers import lockfile
-from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, \
+from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, Topic, \
     Subscription, Recipient, Message, Attachment, UserMessage, valid_stream_name, \
     Client, DefaultStream, UserPresence, Referral, PushDeviceToken, MAX_SUBJECT_LENGTH, \
     MAX_MESSAGE_LENGTH, get_client, get_stream, get_recipient, get_huddle, \
@@ -656,6 +656,7 @@ def do_send_messages(messages):
                                         if user_profile.is_active]
         message['message'].maybe_render_content(None)
         message['message'].update_calculated_fields()
+        message['message'].update_topic()
 
     # Save the message receipts in the database
     user_message_flags = defaultdict(dict) # type: Dict[int, Dict[int, List[str]]]
@@ -2450,11 +2451,21 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
         event["orig_subject"] = orig_subject
         event["propagate_mode"] = propagate_mode
         message.subject = subject
+
+        # We always create a new topic now for topic edits.  For the
+        # "change_all" case, you could argue we should just reuse the old
+        # zerver_topic row, but that optimization may cause problems if we decide to
+        # expose the history of topic name changes.  Also, even the "change_all"
+        # case is limited to a two-day range as this comment is being written.
+        message.topic, created = Topic.objects.get_or_create(
+            name=subject,
+            recipient=message.recipient)
+        new_topic_id = message.topic_id
+
         event["stream_id"] = message.recipient.type_id
         event["subject"] = subject
         event['subject_links'] = bugdown.subject_links(message.sender.realm.domain.lower(), subject)
         edit_history_event["prev_subject"] = orig_subject
-
 
         if propagate_mode in ["change_later", "change_all"]:
             propagate_query = Q(recipient = message.recipient, subject = orig_subject)
@@ -2472,12 +2483,13 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
 
             # Evaluate the query before running the update
             messages_list = list(messages)
-            messages.update(subject=subject)
+            messages.update(subject=subject, topic_id=new_topic_id)
 
             for m in messages_list:
                 # The cached ORM object is not changed by messages.update()
                 # and the remote cache update requires the new value
                 m.subject = subject
+                m.topic_id = new_topic_id
 
             changed_messages += messages_list
 
@@ -2491,7 +2503,7 @@ def do_update_message(user_profile, message_id, subject, propagate_mode, content
     message.edit_history = ujson.dumps(edit_history)
 
     log_event(event)
-    message.save(update_fields=["subject", "content", "rendered_content",
+    message.save(update_fields=["topic_id", "subject", "content", "rendered_content",
                                 "rendered_content_version", "last_edit_time",
                                 "edit_history"])
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -187,6 +187,10 @@ def get_user_messages(user_profile):
         order_by('message')
     return [um.message for um in query]
 
+def subject_topic_awareness(test_obj):
+    return test_obj.settings(CATCH_TOPIC_MIGRATION_BUGS=False)
+
+
 class DummyHandler(object):
     def __init__(self):
         # type: (Callable) -> None

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -187,8 +187,8 @@ def get_user_messages(user_profile):
         order_by('message')
     return [um.message for um in query]
 
-def subject_topic_awareness(test_obj):
-    return test_obj.settings(CATCH_TOPIC_MIGRATION_BUGS=False)
+def subject_topic_awareness(test_obj, new_topics=False):
+    return test_obj.settings(CATCH_TOPIC_MIGRATION_BUGS=new_topics)
 
 
 class DummyHandler(object):

--- a/zerver/migrations/0025_add_topic_table.py
+++ b/zerver/migrations/0025_add_topic_table.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import zerver.lib.str_utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0024_realm_allow_message_editing'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Topic',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=60, db_index=True)),
+                ('recipient', models.ForeignKey(to='zerver.Recipient')),
+            ],
+            bases=(zerver.lib.str_utils.ModelReprMixin, models.Model),
+        ),
+        migrations.AddField(
+            model_name='message',
+            name='topic',
+            field=models.ForeignKey(to='zerver.Topic', null=True),
+        ),
+    ]

--- a/zerver/migrations/0026_topics_backfill.py
+++ b/zerver/migrations/0026_topics_backfill.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import zerver.lib.str_utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0025_add_topic_table'),
+    ]
+
+    operations = [
+        migrations.RunSQL("""
+            insert into zerver_topic (recipient_id, name)
+            select distinct recipient_id, subject from zerver_message where subject != ''
+            """
+        )
+    ]

--- a/zerver/migrations/0027_usertopic.py
+++ b/zerver/migrations/0027_usertopic.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import zerver.lib.str_utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0026_topics_backfill'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserTopic',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('is_muted', models.BooleanField(default=False, db_index=True)),
+                ('topic', models.ForeignKey(to='zerver.Topic')),
+                ('user_profile', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+            bases=(zerver.lib.str_utils.ModelReprMixin, models.Model),
+        ),
+        migrations.AlterUniqueTogether(
+            name='usertopic',
+            unique_together=set([('user_profile', 'topic')]),
+        ),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -791,11 +791,10 @@ class Message(ModelReprMixin, models.Model):
 
     def topic_name(self):
         # type: () -> text_type
-        """
-        Please start using this helper to facilitate an
-        eventual switch over to a separate topic table.
-        """
-        return self.subject
+        if self.topic:
+            return self.topic.name
+        else:
+            return self.subject
 
     def __unicode__(self):
         # type: () -> text_type
@@ -1153,6 +1152,9 @@ class Message(ModelReprMixin, models.Model):
             self.topic, _ = Topic.objects.get_or_create(
                 name=self.subject,
                 recipient=self.recipient)
+        if self.subject:
+            if getattr(settings, 'CATCH_TOPIC_MIGRATION_BUGS', False):
+                self.subject = 'CATCH_TOPIC_MIGRATION_BUGS'
 
 
 @receiver(pre_save, sender=Message)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -769,6 +769,29 @@ class Topic(ModelReprMixin, models.Model):
     recipient = models.ForeignKey(Recipient) # type: Recipient
     name = models.CharField(max_length=MAX_SUBJECT_LENGTH, db_index=True) # type: text_type
 
+    @staticmethod
+    def get_topics_from_names(realm, name_dicts):
+        # type: (Realm, List[Dict[text_type, text_type]) -> List[Topic]
+
+        # TODO: Handle non-existent stream/topics.
+        # TODO: Make this work with a single bulk query.
+        topics = set()
+
+        for nd in name_dicts:
+            stream_name = nd['stream_name']
+            topic_name = nd['topic_name']
+            stream = get_stream(stream_name, realm)
+            recipient = get_recipient(Recipient.STREAM, stream.id)
+            try:
+                topic = Topic.objects.get(
+                    recipient_id=recipient.id,
+                    name=topic_name)
+            except Topic.DoesNotExist:
+                continue
+            topics.add(topic)
+
+        return topics
+
     def __unicode__(self):
         # type: () -> text_type
         return u"<Topic: %s>" % (self.name,)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -773,6 +773,22 @@ class Topic(ModelReprMixin, models.Model):
         # type: () -> text_type
         return u"<Topic: %s>" % (self.name,)
 
+class UserTopic(ModelReprMixin, models.Model):
+    user_profile = models.ForeignKey(UserProfile) # type: UserProfile
+    topic = models.ForeignKey(Topic) # type: Topic
+    is_muted = models.BooleanField(default=False, db_index=True) # type: bool
+
+    class Meta(object):
+        unique_together = ("user_profile", "topic")
+
+    def __unicode__(self):
+        # type: () -> text_type
+        return u"<UserTopic: %s / %s (%s)>" % (
+            self.user_profile.email,
+            self.topic.name,
+            self.flags_list()
+        )
+
 class Message(ModelReprMixin, models.Model):
     sender = models.ForeignKey(UserProfile) # type: UserProfile
     recipient = models.ForeignKey(Recipient) # type: Recipient

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -804,6 +804,28 @@ class UserTopic(ModelReprMixin, models.Model):
     class Meta(object):
         unique_together = ("user_profile", "topic")
 
+    def stream_name(self):
+        stream = Stream.objects.get(id=self.topic.recipient.type_id)
+        return stream.name
+
+    def topic_name(self):
+        return self.topic.name
+
+    @staticmethod
+    def get_muted_stream_topic_names_for_user(user_profile):
+        # TODO: optimize
+
+        user_topics = UserTopic.objects.filter(
+            user_profile=user_profile,
+            is_muted=True,
+            )
+        return {
+            (
+                user_topic.stream_name(),
+                user_topic.topic_name(),
+            ) for user_topic in user_topics
+        }
+
     def __unicode__(self):
         # type: () -> text_type
         return u"<UserTopic: %s / %s (%s)>" % (

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1170,7 +1170,7 @@ def get_context_for_message(message):
     # TODO: Change return type to QuerySet[Message]
     return Message.objects.filter(
         recipient_id=message.recipient_id,
-        subject=message.subject,
+        topic_id=message.topic_id,
         id__lt=message.id,
         pub_date__gt=message.pub_date - timedelta(minutes=15),
     ).order_by('-id')[:10]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -765,9 +765,18 @@ def to_dict_cache_key(message, apply_markdown):
     # type: (Message, bool) -> text_type
     return to_dict_cache_key_id(message.id, apply_markdown)
 
+class Topic(ModelReprMixin, models.Model):
+    recipient = models.ForeignKey(Recipient) # type: Recipient
+    name = models.CharField(max_length=MAX_SUBJECT_LENGTH, db_index=True) # type: text_type
+
+    def __unicode__(self):
+        # type: () -> text_type
+        return u"<Topic: %s>" % (self.name,)
+
 class Message(ModelReprMixin, models.Model):
     sender = models.ForeignKey(UserProfile) # type: UserProfile
     recipient = models.ForeignKey(Recipient) # type: Recipient
+    topic = models.ForeignKey(Topic, null=True)
     subject = models.CharField(max_length=MAX_SUBJECT_LENGTH, db_index=True) # type: text_type
     content = models.TextField() # type: text_type
     rendered_content = models.TextField(null=True) # type: Optional[text_type]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -896,7 +896,7 @@ class Message(ModelReprMixin, models.Model):
                 last_edit_time = self.last_edit_time,
                 edit_history = self.edit_history,
                 content = self.content,
-                subject = self.subject,
+                subject = self.topic_name(),
                 pub_date = self.pub_date,
                 rendered_content = self.rendered_content,
                 rendered_content_version = self.rendered_content_version,
@@ -914,6 +914,14 @@ class Message(ModelReprMixin, models.Model):
         )
 
     @staticmethod
+    def get_topic_name_from_raw_data(row):
+        # TODO: inline this when topic id transition finishes
+        if row['topic__name']:
+            return row['topic__name']
+        else:
+            return row['subject']
+
+    @staticmethod
     def build_dict_from_raw_db_row(row, apply_markdown):
         # type: (Dict[str, Any], bool) -> Dict[str, Any]
         '''
@@ -927,7 +935,7 @@ class Message(ModelReprMixin, models.Model):
                 last_edit_time = row['last_edit_time'],
                 edit_history = row['edit_history'],
                 content = row['content'],
-                subject = row['subject'],
+                subject = Message.get_topic_name_from_raw_data(row),
                 pub_date = row['pub_date'],
                 rendered_content = row['rendered_content'],
                 rendered_content_version = row['rendered_content_version'],
@@ -1096,6 +1104,7 @@ class Message(ModelReprMixin, models.Model):
             'sender__realm__domain',
             'sender__avatar_source',
             'sender__is_mirror_dummy',
+            'topic__name',
         ]
         return Message.objects.filter(id__in=needed_ids).values(*fields)
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1148,12 +1148,20 @@ class Message(ModelReprMixin, models.Model):
         self.has_image = bool(Message.content_has_image(content))
         self.has_link = bool(Message.content_has_link(content))
 
+    def update_topic(self):
+        if self.subject and not self.topic:
+            self.topic, _ = Topic.objects.get_or_create(
+                name=self.subject,
+                recipient=self.recipient)
+
+
 @receiver(pre_save, sender=Message)
 def pre_save_message(sender, **kwargs):
     # type: (Any, **Any) -> None
     if kwargs['update_fields'] is None or "content" in kwargs['update_fields']:
         message = kwargs['instance']
         message.update_calculated_fields()
+        message.update_topic()
 
 def get_context_for_message(message):
     # type: (Message) -> Sequence[Message]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1064,6 +1064,8 @@ class Message(ModelReprMixin, models.Model):
 
     def to_log_dict(self):
         # type: () -> Dict[str, Any]
+        # TODO: This function doesn't have meaningful test
+        # coverage on what subject returns.
         return dict(
             id                = self.id,
             sender_id         = self.sender.id,
@@ -1074,7 +1076,7 @@ class Message(ModelReprMixin, models.Model):
             sending_client    = self.sending_client.name,
             type              = self.recipient.type_name(),
             recipient         = get_display_recipient(self.recipient),
-            subject           = self.subject,
+            subject           = self.topic_name(),
             content           = self.content,
             timestamp         = datetime_to_timestamp(self.pub_date))
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -49,7 +49,9 @@ from zerver.lib.actions import (
 )
 
 from zerver.lib.event_queue import allocate_client_descriptor
-from zerver.lib.test_helpers import AuthedTestCase, POSTRequestMock
+from zerver.lib.test_helpers import (
+    AuthedTestCase, POSTRequestMock, create_stream_topic_for_testing,
+    )
 from zerver.lib.validator import (
     check_bool, check_dict, check_int, check_list, check_string,
     equals, check_none_or, Validator
@@ -399,6 +401,10 @@ class EventsRegisterTest(AuthedTestCase):
 
     def test_muted_topics_events(self):
         # type: () -> None
+        realm = get_realm('zulip.com')
+        create_stream_topic_for_testing(realm=realm,
+            stream_name='Denmark', topic_name='topic')
+
         muted_topics_checker = check_dict([
             ('type', equals('muted_topics')),
             ('muted_topics', check_list(check_list(check_string, 2))),

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -319,7 +319,7 @@ class StreamMessagesTest(AuthedTestCase):
         with queries_captured() as queries:
             send_message()
 
-        self.assert_length(queries, 7)
+        self.assert_length(queries, 8)
 
     def test_message_mentions(self):
         user_profile = get_user_profile_by_email("iago@zulip.com")
@@ -758,13 +758,15 @@ class MessagePOSTTest(AuthedTestCase):
         user.realm.save()
 
 class EditMessageTest(AuthedTestCase):
-    def check_message(self, msg_id, subject=None, content=None):
+    def check_message(self, msg_id, subject=None, content=None, edited=True):
         msg = Message.objects.get(id=msg_id)
         cached = msg.to_dict(False)
         uncached = msg.to_dict_uncached_helper(False)
         self.assertEqual(cached, uncached)
         if subject:
             self.assertEqual(msg.topic_name(), subject)
+            if edited:
+                self.assertEqual(msg.topic.name, subject)
         if content:
             self.assertEqual(msg.content, content)
         return msg
@@ -842,8 +844,8 @@ class EditMessageTest(AuthedTestCase):
 
         self.check_message(id1, subject="edited")
         self.check_message(id2, subject="edited")
-        self.check_message(id3, subject="topic1")
-        self.check_message(id4, subject="topic2")
+        self.check_message(id3, subject="topic1", edited=False)
+        self.check_message(id4, subject="topic2", edited=False)
         self.check_message(id5, subject="edited")
 
     def test_propagate_all_topics(self):
@@ -871,10 +873,10 @@ class EditMessageTest(AuthedTestCase):
 
         self.check_message(id1, subject="edited")
         self.check_message(id2, subject="edited")
-        self.check_message(id3, subject="topic1")
-        self.check_message(id4, subject="topic2")
+        self.check_message(id3, subject="topic1", edited=False)
+        self.check_message(id4, subject="topic2", edited=False)
         self.check_message(id5, subject="edited")
-        self.check_message(id6, subject="topic3")
+        self.check_message(id6, subject="topic3", edited=False)
 
 class StarTests(AuthedTestCase):
 

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -785,7 +785,7 @@ class EditMessageTest(AuthedTestCase):
         self.assert_json_success(result)
         self.check_message(msg_id, content="after edit")
 
-        with subject_topic_awareness(self): # edit
+        with subject_topic_awareness(self, new_topics=True): # edit
             result = self.client.post("/json/update_message", {
                 'message_id': msg_id,
                 'subject': 'edited'
@@ -824,7 +824,7 @@ class EditMessageTest(AuthedTestCase):
 
     def test_propagate_topic_forward(self):
         self.login("hamlet@zulip.com")
-        with subject_topic_awareness(self): # edit
+        with subject_topic_awareness(self, new_topics=True): # edit
             id1 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
                 subject="topic1")
             id2 = self.send_message("iago@zulip.com", "Scotland", Recipient.STREAM,
@@ -851,7 +851,7 @@ class EditMessageTest(AuthedTestCase):
 
     def test_propagate_all_topics(self):
         self.login("hamlet@zulip.com")
-        with subject_topic_awareness(self): # edit
+        with subject_topic_awareness(self, new_topics=True): # edit
             id1 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,
                 subject="topic1")
             id2 = self.send_message("hamlet@zulip.com", "Scotland", Recipient.STREAM,

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -402,7 +402,7 @@ class MessageTopicTest(TestCase):
                 last_edit_time=datetime.datetime.now(),
                 edit_history='[]'
             )
-            with subject_topic_awareness(self):
+            with subject_topic_awareness(self, new_topics=True):
                 message.save()
             messages.append(message)
 
@@ -417,7 +417,7 @@ class MessageTopicTest(TestCase):
         for message in messages:
             msg = Message.objects.get(id=message.id)
             self.assertEqual(msg.topic_id, topic_id)
-            self.assertEqual(msg.subject, 'lunch')
+            self.assertNotEqual(msg.subject, 'lunch')
 
 class MessageDictTest(AuthedTestCase):
     @slow(1.6, 'builds lots of messages')

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -402,7 +402,8 @@ class MessageTopicTest(TestCase):
                 last_edit_time=datetime.datetime.now(),
                 edit_history='[]'
             )
-            message.save()
+            with subject_topic_awareness(self):
+                message.save()
             messages.append(message)
 
         lunch_topics = Topic.objects.filter(

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -19,7 +19,8 @@ from zerver.lib.test_helpers import (
 
 from zerver.models import (
     MAX_MESSAGE_LENGTH, MAX_SUBJECT_LENGTH,
-    Client, Message, Realm, Recipient, Stream, UserMessage, UserProfile, Attachment,
+    Client, Message, Realm, Recipient,
+    Stream, UserMessage, UserProfile, Attachment, Topic,
     get_realm, get_stream, get_user_profile_by_email,
 )
 
@@ -380,6 +381,42 @@ class StreamMessagesTest(AuthedTestCase):
 
         self.assert_stream_message(non_ascii_stream_name, subject=u"hümbüǵ",
                                    content=u"hümbüǵ")
+
+class MessageTopicTest(TestCase):
+    def test_message_hooks(self):
+        realm = get_realm("zulip.com")
+        sender = get_user_profile_by_email('othello@zulip.com')
+        stream, _ = create_stream_if_needed(realm, 'devel')
+        stream_recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
+        sending_client, _ = Client.objects.get_or_create(name="test suite")
+
+        messages = []
+        for i in range(3):
+            message = Message(
+                sender=sender,
+                recipient=stream_recipient,
+                subject='lunch',
+                content='whatever %d' % (i,),
+                pub_date=datetime.datetime.now(),
+                sending_client=sending_client,
+                last_edit_time=datetime.datetime.now(),
+                edit_history='[]'
+            )
+            message.save()
+            messages.append(message)
+
+        lunch_topics = Topic.objects.filter(
+            name='lunch',
+            recipient=stream_recipient,
+        )
+        self.assertEqual(len(lunch_topics), 1)
+        topic_id = lunch_topics[0].id
+
+        # Make sure we write legacy/new fields.
+        for message in messages:
+            msg = Message.objects.get(id=message.id)
+            self.assertEqual(msg.topic_id, topic_id)
+            self.assertEqual(msg.subject, 'lunch')
 
 class MessageDictTest(AuthedTestCase):
     @slow(1.6, 'builds lots of messages')

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -442,7 +442,7 @@ class MessageDictTest(AuthedTestCase):
                     last_edit_time=datetime.datetime.now(),
                     edit_history='[]'
                 )
-                with subject_topic_awareness(self):
+                with subject_topic_awareness(self, new_topics=True):
                     message.save()
 
         ids = [row['id'] for row in Message.objects.all().values('id')]

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -12,6 +12,7 @@ from zerver.lib.actions import create_stream_if_needed, do_add_subscription
 from zerver.lib.test_helpers import (
     AuthedTestCase, POSTRequestMock,
     get_user_messages, message_ids, queries_captured,
+    subject_topic_awareness,
 )
 from zerver.views.messages import (
     exclude_muting_conditions, get_sqlalchemy_connection,
@@ -430,10 +431,11 @@ class GetOldMessagesTest(AuthedTestCase):
         do_add_subscription(get_user_profile_by_email("starnine@mit.edu"),
                             stream, no_log=True)
 
-        self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
-                          subject=u"\u03bb-topic")
-        self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
-                          subject=u"\u03bb-topic.d")
+        with subject_topic_awareness(self): # narrow
+            self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
+                              subject=u"\u03bb-topic")
+            self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
+                              subject=u"\u03bb-topic.d")
 
         narrow = [dict(operator='topic', operand=u'\u03bb-topic')]
         result = self.post_with_params(dict(num_after=2, narrow=ujson.dumps(narrow)))

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -5,7 +5,7 @@ from sqlalchemy.sql import (
 )
 
 from zerver.models import (
-    Realm, Recipient, Stream, Subscription, UserProfile, Attachment,
+    Realm, Recipient, Stream, Subscription, UserProfile, Attachment, Topic,
     get_display_recipient, get_recipient, get_realm, get_stream, get_user_profile_by_email,
 )
 from zerver.lib.actions import create_stream_if_needed, do_add_subscription
@@ -51,6 +51,13 @@ class NarrowBuilderTest(AuthedTestCase):
         self.builder = NarrowBuilder(self.user_profile, column('id'))
         self.raw_query = select([column("id")], None, "zerver_message")
 
+    def _create_topic(self, name):
+        stream = get_stream("Scotland", self.realm)
+        return Topic.objects.get_or_create(
+            name=name,
+            recipient=get_recipient(Recipient.STREAM, stream.id)
+        )
+
     def test_add_term_using_not_defined_operator(self):
         term = dict(operator='not-defined', operand='any')
         self.assertRaises(BadNarrowOperator, self._build_query, term)
@@ -90,20 +97,24 @@ class NarrowBuilderTest(AuthedTestCase):
         self.assertRaises(BadNarrowOperator, self._build_query, term)
 
     def test_add_term_using_topic_operator_and_lunch_operand(self):
+        self._create_topic('lunch')
         term = dict(operator='topic', operand='lunch')
-        self._do_add_term_test(term, 'WHERE upper(subject) = upper(:param_1)')
+        self._do_add_term_test(term, 'WHERE topic_id IN (:topic_id_1)')
 
     def test_add_term_using_topic_operator_lunch_operand_and_negated(self):  # NEGATED
+        self._create_topic('lunch')
         term = dict(operator='topic', operand='lunch', negated=True)
-        self._do_add_term_test(term, 'WHERE upper(subject) != upper(:param_1)')
+        self._do_add_term_test(term, 'WHERE topic_id NOT IN (:topic_id_1)')
 
     def test_add_term_using_topic_operator_and_personal_operand(self):
+        self._create_topic('personal')
         term = dict(operator='topic', operand='personal')
-        self._do_add_term_test(term, 'WHERE upper(subject) = upper(:param_1)')
+        self._do_add_term_test(term, 'WHERE topic_id IN (:topic_id_1)')
 
     def test_add_term_using_topic_operator_personal_operand_and_negated(self):  # NEGATED
+        self._create_topic('personal')
         term = dict(operator='topic', operand='personal', negated=True)
-        self._do_add_term_test(term, 'WHERE upper(subject) != upper(:param_1)')
+        self._do_add_term_test(term, 'WHERE topic_id NOT IN (:topic_id_1)')
 
     def test_add_term_using_sender_operator(self):
         term = dict(operator='sender', operand='othello@zulip.com')
@@ -308,6 +319,12 @@ class GetOldMessagesTest(AuthedTestCase):
         query_ids['othello_id'] = othello_user.id
         query_ids['hamlet_recipient'] = get_recipient(Recipient.PERSONAL, hamlet_user.id).id
         query_ids['othello_recipient'] = get_recipient(Recipient.PERSONAL, othello_user.id).id
+        blah_topic, created= Topic.objects.get_or_create(
+            name='blah',
+            recipient_id=query_ids['hamlet_recipient'],
+            )
+        query_ids['blah_topic_id'] = blah_topic.id
+
 
         return query_ids
 
@@ -431,7 +448,7 @@ class GetOldMessagesTest(AuthedTestCase):
         do_add_subscription(get_user_profile_by_email("starnine@mit.edu"),
                             stream, no_log=True)
 
-        with subject_topic_awareness(self): # narrow
+        with subject_topic_awareness(self, new_topics=True): # narrow
             self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
                               subject=u"\u03bb-topic")
             self.send_message("starnine@mit.edu", "Scotland", Recipient.STREAM,
@@ -749,13 +766,13 @@ class GetOldMessagesTest(AuthedTestCase):
                                                   'narrow': '[["stream", "Scotland"]]'},
                                                  sql)
 
-        sql_template = "SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND upper(subject) = upper('blah') AND message_id >= 0 ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC"
+        sql_template = "SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND topic_id IN ({blah_topic_id}) AND message_id >= 0 ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC"
         sql = sql_template.format(**query_ids)
         self.common_check_get_old_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 10,
                                                   'narrow': '[["topic", "blah"]]'},
                                                  sql)
 
-        sql_template = "SELECT anon_1.message_id \nFROM (SELECT id AS message_id \nFROM zerver_message \nWHERE recipient_id = {scotland_recipient} AND upper(subject) = upper('blah') AND zerver_message.id >= 0 ORDER BY zerver_message.id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC"
+        sql_template = "SELECT anon_1.message_id \nFROM (SELECT id AS message_id \nFROM zerver_message \nWHERE recipient_id = {scotland_recipient} AND topic_id IN ({blah_topic_id}) AND zerver_message.id >= 0 ORDER BY zerver_message.id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC"
         sql = sql_template.format(**query_ids)
         self.common_check_get_old_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 10,
                                                   'narrow': '[["stream", "Scotland"], ["topic", "blah"]]'},

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -7,7 +7,11 @@ from zerver.models import (
     get_user_profile_by_email, Recipient, UserMessage
 )
 
-from zerver.lib.test_helpers import AuthedTestCase, tornado_redirected_to_list
+from zerver.lib.test_helpers import (
+    AuthedTestCase,
+    subject_topic_awareness,
+    tornado_redirected_to_list,
+)
 import ujson
 
 class PointerTest(AuthedTestCase):
@@ -206,7 +210,8 @@ class UnreadCountTests(AuthedTestCase):
         user_profile = get_user_profile_by_email("hamlet@zulip.com")
         self.subscribe_to_stream(user_profile.email, "test_stream", user_profile.realm)
 
-        message_id = self.send_message("hamlet@zulip.com", "test_stream", Recipient.STREAM, "hello", "test_topic")
+        with subject_topic_awareness(self): # unread
+            message_id = self.send_message("hamlet@zulip.com", "test_stream", Recipient.STREAM, "hello", "test_topic")
         unrelated_message_id = self.send_message("hamlet@zulip.com", "Denmark", Recipient.STREAM, "hello", "Denmark2")
         events = [] # type: List[Dict[str, Any]]
         with tornado_redirected_to_list(events):

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -210,7 +210,7 @@ class UnreadCountTests(AuthedTestCase):
         user_profile = get_user_profile_by_email("hamlet@zulip.com")
         self.subscribe_to_stream(user_profile.email, "test_stream", user_profile.realm)
 
-        with subject_topic_awareness(self): # unread
+        with subject_topic_awareness(self, new_topics=True): # unread
             message_id = self.send_message("hamlet@zulip.com", "test_stream", Recipient.STREAM, "hello", "test_topic")
         unrelated_message_id = self.send_message("hamlet@zulip.com", "Denmark", Recipient.STREAM, "hello", "Denmark2")
         events = [] # type: List[Dict[str, Any]]

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -12,6 +12,7 @@ from zerver.lib.test_helpers import (
     queries_captured, simulated_empty_cache, skip_py3,
     simulated_queue_client, tornado_redirected_to_list, AuthedTestCase,
     most_recent_usermessage, most_recent_message,
+    subject_topic_awareness,
 )
 
 from zerver.models import UserProfile, Recipient, \
@@ -1775,19 +1776,20 @@ class TestMissedMessages(AuthedTestCase):
         tokens = [str(random.getrandbits(32)) for _ in range(30)]
         mock_random_token.side_effect = tokens
 
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '0')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '1')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '2')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '3')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '4')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '5')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '6')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '7')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '8')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '9')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '10')
-        self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '11', subject='test2')
-        msg_id = self.send_message("othello@zulip.com", "denmark", Recipient.STREAM, '@**hamlet**')
+        with subject_topic_awareness(self): # emails
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '0')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '1')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '2')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '3')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '4')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '5')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '6')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '7')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '8')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '9')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '10')
+            self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '11', subject='test2')
+            msg_id = self.send_message("othello@zulip.com", "denmark", Recipient.STREAM, '@**hamlet**')
 
         othello = get_user_profile_by_email('othello@zulip.com')
         hamlet = get_user_profile_by_email('hamlet@zulip.com')
@@ -1813,9 +1815,10 @@ class TestMissedMessages(AuthedTestCase):
         tokens = [str(random.getrandbits(32)) for _ in range(30)]
         mock_random_token.side_effect = tokens
 
-        msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
-                                   Recipient.PERSONAL,
-                                   'Extremely personal message!')
+        with subject_topic_awareness(self): # emails
+            msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
+                                       Recipient.PERSONAL,
+                                       'Extremely personal message!')
 
         othello = get_user_profile_by_email('othello@zulip.com')
         hamlet = get_user_profile_by_email('hamlet@zulip.com')

--- a/zerver/tests/tests.py
+++ b/zerver/tests/tests.py
@@ -1776,7 +1776,7 @@ class TestMissedMessages(AuthedTestCase):
         tokens = [str(random.getrandbits(32)) for _ in range(30)]
         mock_random_token.side_effect = tokens
 
-        with subject_topic_awareness(self): # emails
+        with subject_topic_awareness(self, new_topics=True): # emails
             self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '0')
             self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '1')
             self.send_message("othello@zulip.com", "Denmark", Recipient.STREAM, '2')
@@ -1815,7 +1815,7 @@ class TestMissedMessages(AuthedTestCase):
         tokens = [str(random.getrandbits(32)) for _ in range(30)]
         mock_random_token.side_effect = tokens
 
-        with subject_topic_awareness(self): # emails
+        with subject_topic_awareness(self, new_topics=True): # emails
             msg_id = self.send_message("othello@zulip.com", "hamlet@zulip.com",
                                        Recipient.PERSONAL,
                                        'Extremely personal message!')

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -26,7 +26,7 @@ from zerver.lib.response import json_success, json_error
 from zerver.lib.utils import statsd
 from zerver.lib.validator import \
     check_list, check_int, check_dict, check_string, check_bool
-from zerver.models import Message, UserProfile, Stream, Subscription, \
+from zerver.models import Message, UserProfile, Stream, Subscription, Topic, \
     Recipient, UserMessage, bulk_get_recipients, get_recipient, \
     get_user_profile_by_email, get_stream, valid_stream_name, \
     parse_usermessage_flags, to_dict_cache_key_id, extract_message_dict, \
@@ -620,19 +620,28 @@ def update_message_flags(request, user_profile,
     log_data_str = "[%s %s/%s]" % (operation, flag, target_count_str)
     request._log_data["extra"] = log_data_str
     stream = None
+    topic_id = None
     if stream_name is not None:
         stream = get_stream(stream_name, user_profile.realm)
         if not stream:
             raise JsonableError(_('No such stream \'%s\'') % (stream_name,))
         if topic_name:
-            topic_exists = UserMessage.objects.filter(user_profile=user_profile,
-                                                      message__recipient__type_id=stream.id,
-                                                      message__recipient__type=Recipient.STREAM,
-                                                      message__subject__iexact=topic_name).exists()
+            # TODO: If we want to support legacy subject names here, we
+            #       need to make this more complicated.
+            topics = Topic.objects.filter(
+                recipient__type_id=stream.id,
+                recipient__type=Recipient.STREAM,
+                name__iexact=topic_name)
+            topic_exists = len(topics) == 1
+            if topic_exists:
+                topic_id = topics[0].id
+                topic_exists = UserMessage.objects.filter(
+                    user_profile=user_profile,
+                    message__topic_id=topic_id).exists()
             if not topic_exists:
                 raise JsonableError(_('No such topic \'%s\'') % (topic_name,))
     count = do_update_message_flags(user_profile, operation, flag, messages,
-                                    all, stream, topic_name)
+                                    all, stream, topic_id=topic_id)
 
     # If we succeed, update log data str with the actual count for how
     # many messages were updated.

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -212,10 +212,14 @@ class NarrowBuilder(object):
             else:
                 regex = r'^%s(\.d)*$' % (self._pg_re_escape(base_topic),)
 
-            cond = column("subject").op("~*")(regex)
+            topics = Topic.objects.filter(name__iregex=regex)
+            topic_ids = [topic.id for topic in topics]
+            cond = column("topic_id").in_(topic_ids)
             return query.where(maybe_negate(cond))
 
-        cond = func.upper(column("subject")) == func.upper(literal(operand))
+        topics = Topic.objects.filter(name__iexact=operand)
+        topic_ids = [topic.id for topic in topics]
+        cond = column("topic_id").in_(topic_ids)
         return query.where(maybe_negate(cond))
 
     def by_sender(self, query, operand, maybe_negate):

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -51,6 +51,8 @@ USING_RABBITMQ = False
 # Disable the tutorial because it confuses the client tests.
 TUTORIAL_ENABLED = False
 
+CATCH_TOPIC_MIGRATION_BUGS = True
+
 # Disable use of memcached for caching
 CACHES['database'] = {
     'BACKEND':  'django.core.cache.backends.dummy.DummyCache',


### PR DESCRIPTION
@timabbott This is an initial look at how muting topics would work with a Topic table, to help address #1019.  So far I only touch the back end code.  The current series may actually be a minor performance regression, because the front end still pushes O(N) muted topics to us, and now we have to update O(N) rows on the back end, which is presumably more expensive than writing an O(N) json field in Python.  I doubt that performance is terrible in either case.

Additional commits would make the front end just communicate O(1) changes to the server.

There is also no data backfill yet in this series.  I'm thinking of just doing a lazy backfill--if you try to examine which topics are muted, we check for UserProfile.muted_topics having "migrated" as its value.  If muted_topics is not "migrated" but is instead still valid legacy json, we do the migration to UserTopic and write "migrated" to UserProfile.muted_topics.

This series also does not address `approximate_unread_count`, which seems to have totally non-sensical handling of muted topics, and it has no test coverage to boot.  I'll open a separate ticket for that.
